### PR TITLE
Skip metadata lookup by default

### DIFF
--- a/src/Entity/Ioda/MetadataEntity.php
+++ b/src/Entity/Ioda/MetadataEntity.php
@@ -158,7 +158,7 @@ class MetadataEntity
     /**
      * @return string
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/src/Entity/Outages/OutagesEvent.php
+++ b/src/Entity/Outages/OutagesEvent.php
@@ -99,6 +99,16 @@ class OutagesEvent
     }
 
     /**
+     * @param MetadataEntity $entity
+     * @return OutagesEvent
+     */
+    public function setEntity(MetadataEntity $entity): OutagesEvent
+    {
+        $this->entity = $entity;
+        return $this;
+    }
+
+    /**
      * @return int
      */
     public function getFrom(): int

--- a/src/Entity/Outages/OutagesSummary.php
+++ b/src/Entity/Outages/OutagesSummary.php
@@ -77,7 +77,7 @@ class OutagesSummary
     /**
      * @return MetadataEntity
      */
-    public function getEntity(): MetadataEntity
+    public function getEntity(): ?MetadataEntity
     {
         return $this->entity;
     }


### PR DESCRIPTION
Skip entity lookup when search for alerts, events, and summaries. This
significantly boost the performance of lookup calls.

Added `includeMetadata` parameter to allow calls to still conduct lookup.