### PR TITLE
add event_cnt for summary endpoint

### DIFF
--- a/src/Controller/OutagesController.php
+++ b/src/Controller/OutagesController.php
@@ -814,6 +814,10 @@ class OutagesController extends ApiController
      *                              ),
      *                          ),
      *                          @SWG\Property(
+     *                              property="event_cnt",
+     *                              type="number"
+     *                          ),
+     *                          @SWG\Property(
      *                              property="entity",
      *                              ref=@Model(type=\App\Entity\MetadataEntity::class, groups={"public"})
      *                          )

--- a/src/Entity/OutagesSummary.php
+++ b/src/Entity/OutagesSummary.php
@@ -44,10 +44,11 @@ class OutagesSummary
     /**
      * Constructor
      */
-    public function __construct($scores, $entity)
+    public function __construct($scores, $entity, $event_cnt)
     {
         $this->scores = $scores;
         $this->entity = $entity;
+        $this->event_cnt = $event_cnt;
     }
 
     /////////////////////
@@ -92,6 +93,24 @@ class OutagesSummary
         return $this;
     }
 
+    /**
+     * @return int
+     */
+    public function getEventCnt(): int
+    {
+        return $this->event_cnt;
+    }
+
+    /**
+     * @param int $event_cnt
+     * @return OutagesSummary
+     */
+    public function setEventCnt(int $event_cnt): OutagesSummary
+    {
+        $this->event_cnt = $event_cnt;
+        return $this;
+    }
+
 
 
     //////////////////////////
@@ -105,6 +124,12 @@ class OutagesSummary
      * @var array
      */
     private $scores;
+
+    /**
+     * @Groups({"public"})
+     * @var integer
+     */
+    private $event_cnt;
 
     /**
      * @Groups({"public"})

--- a/src/Service/OutagesEventsService.php
+++ b/src/Service/OutagesEventsService.php
@@ -311,7 +311,7 @@ class OutagesEventsService
             // all alerts here have the entity
             $eventmap = $this->buildEvents($alerts, $from, $until);
             $scores = $this->computeSummaryScores($eventmap);
-            $res[] = new OutagesSummary($scores, $alerts[0]->getEntity());
+            $res[] = new OutagesSummary($scores, $alerts[0]->getEntity(), count($eventmap));
         }
 
 


### PR DESCRIPTION
the `event_cnt` value in the response indicates the number of events a outage summary is built from.