### PR TITLE
Summary events count

### DIFF
--- a/src/Service/OutagesEventsService.php
+++ b/src/Service/OutagesEventsService.php
@@ -284,6 +284,14 @@ class OutagesEventsService
         return $res;
     }
 
+    private function countEventsFromMap($eventMap): int {
+        $count=0;
+        foreach($eventMap as $aid => $events){
+            $count += count($events);
+        }
+        return $count;
+    }
+
     /**
      * Summarize all events during the time period by entities. One summary per
      * entitiy for the entire time period.
@@ -311,7 +319,7 @@ class OutagesEventsService
             // all alerts here have the entity
             $eventmap = $this->buildEvents($alerts, $from, $until);
             $scores = $this->computeSummaryScores($eventmap);
-            $res[] = new OutagesSummary($scores, $alerts[0]->getEntity(), count($eventmap));
+            $res[] = new OutagesSummary($scores, $alerts[0]->getEntity(), $this->countEventsFromMap($eventmap));
         }
 
 

--- a/src/Service/OutagesEventsService.php
+++ b/src/Service/OutagesEventsService.php
@@ -318,6 +318,9 @@ class OutagesEventsService
         foreach($alertGroups as $entity_id => $alerts){
             // all alerts here have the entity
             $eventmap = $this->buildEvents($alerts, $from, $until);
+            if(!$eventmap){
+                continue;
+            }
             $scores = $this->computeSummaryScores($eventmap);
             $res[] = new OutagesSummary($scores, $alerts[0]->getEntity(), $this->countEventsFromMap($eventmap));
         }
@@ -357,7 +360,7 @@ class OutagesEventsService
         $curEvents = []; // curEvents[fqid] -> ongoing event
         foreach ($alerts as &$a) {
             $fqid = $a->getFqid();
-            $aId = $fqid . $a->getMetaType() . $a->getMetaCode();
+            $aId = $fqid . $a->getMetaType() . $a->getMetaCode(); // event identifier
             $level = $a->getLevel();
             $time = $a->getTime();
             $drop = (abs($a->getHistoryValue() -
@@ -424,6 +427,13 @@ class OutagesEventsService
                 $cE['until'] = $until;
                 $cE['X-Overlaps-Window'] = true;
                 $events[$aId][] = $cE;
+            }
+        }
+
+        // remove event keys with empty list of events
+        foreach($events as $aid => $e) {
+            if(count($e)==0){
+                unset ($events[$aid]);
             }
         }
 


### PR DESCRIPTION
Fix an issue where when alert with `normal` level showed up, we generate eventmap with empty events, triggering the summary api to think there are events. 

This fixes #48.