### PR TITLE
Influx: return null values when data points are missing

### DIFF
--- a/src/Service/InfluxService.php
+++ b/src/Service/InfluxService.php
@@ -185,7 +185,7 @@ from(bucket: "$bucket")
     $extra
   )
   $aggr
-  |> aggregateWindow(every: ${step}s, fn: mean, createEmpty: false)
+  |> aggregateWindow(every: ${step}s, fn: mean, createEmpty: true)
   |> yield(name: "mean")
 END;
             $q = str_replace("\n", '', $q);


### PR DESCRIPTION
If we don't do this, our step calculation can get horribly messed
up and it is also not clear which timestamps were missing data
in the values list.